### PR TITLE
Add web-managed ticker and clock for RGB matrix display

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,0 +1,29 @@
+# RGB Matrix Ticker
+
+This project drives two chained 64x32 RGB LED matrix panels (total size
+128x32) using a Raspberry Pi.  It displays the current date/time along
+with configurable stock and cryptocurrency ticker symbols and headlines
+from an RSS news feed.
+
+A small Flask web application exposes endpoints to manage the list of
+symbols and to configure the news feed.
+
+## Usage
+
+1. Install the dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Run the application:
+   ```bash
+   python app.py
+   ```
+3. Interact with the HTTP API, for example:
+   * `POST /tickers` with JSON `{"symbol": "AAPL", "type": "stock"}` to add a stock.
+   * `POST /tickers` with JSON `{"symbol": "btc", "type": "crypto"}` to add a crypto currency.
+   * `DELETE /tickers/AAPL` to remove a symbol.
+   * `POST /news` with JSON `{"feed_url": "https://example.com/rss"}` to set the RSS feed.
+
+The display loop will cycle through the current date/time, the ticker
+values and the latest headlines.
+

--- a/app.py
+++ b/app.py
@@ -1,0 +1,81 @@
+"""Web interface and display loop for the RGB matrix ticker."""
+
+from __future__ import annotations
+
+import logging
+import threading
+import time
+from datetime import datetime
+
+from flask import Flask, jsonify, request
+
+from matrix_display import MatrixDisplay
+from news import NewsFetcher
+from ticker_manager import TickerManager
+
+logging.basicConfig(level=logging.INFO)
+LOGGER = logging.getLogger(__name__)
+
+app = Flask(__name__)
+manager = TickerManager()
+news_fetcher = NewsFetcher()
+display = MatrixDisplay()
+
+
+# ---------------------------------------------------------------------------
+# Background display loop
+
+def display_loop() -> None:
+    while True:
+        now = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+        display.show_message(now)
+        time.sleep(2)
+
+        ticker_str = manager.build_ticker_string()
+        if ticker_str:
+            display.show_message(ticker_str)
+            time.sleep(2)
+
+        headlines = news_fetcher.headline_string()
+        if headlines:
+            display.show_message(headlines)
+            time.sleep(2)
+
+
+threading.Thread(target=display_loop, daemon=True).start()
+
+
+# ---------------------------------------------------------------------------
+# HTTP API
+
+@app.route("/tickers", methods=["GET", "POST"])
+def tickers() -> str:
+    if request.method == "POST":
+        data = request.get_json(force=True)
+        symbol = data.get("symbol")
+        kind = data.get("type", "stock")
+        if not symbol:
+            return jsonify({"error": "missing symbol"}), 400
+        manager.add_ticker(symbol, kind)
+    return jsonify(manager.as_dict())
+
+
+@app.route("/tickers/<symbol>", methods=["DELETE"])
+def delete_ticker(symbol: str) -> str:
+    manager.remove_ticker(symbol)
+    return jsonify({"status": "ok"})
+
+
+@app.route("/news", methods=["GET", "POST"])
+def news() -> str:
+    if request.method == "POST":
+        data = request.get_json(force=True)
+        feed = data.get("feed_url")
+        if feed:
+            news_fetcher.set_feed(feed)
+    return jsonify({"feed_url": news_fetcher.feed_url})
+
+
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", port=8000)
+

--- a/matrix_display.py
+++ b/matrix_display.py
@@ -1,0 +1,82 @@
+"""Matrix display abstraction for RGB LED matrix panels.
+
+This module wraps the `rgbmatrix` library used on Raspberry Pi to drive
+LED panels.  When the library is not available (e.g. during testing), it
+falls back to printing messages to the console so the rest of the
+application can be exercised without hardware.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+try:  # pragma: no cover - hardware library may not be installed
+    from rgbmatrix import RGBMatrix, RGBMatrixOptions, graphics
+except Exception:  # pragma: no cover
+    RGBMatrix = None  # type: ignore
+    RGBMatrixOptions = None  # type: ignore
+    graphics = None  # type: ignore
+
+LOGGER = logging.getLogger(__name__)
+
+
+class MatrixDisplay:
+    """Simple wrapper for a chain of 64x32 RGB LED matrix panels.
+
+    Parameters
+    ----------
+    width: int
+        Total width of the virtual display.  Two 64x32 panels side by side
+        therefore result in ``width=128``.
+    height: int
+        Height of the display.  The panels used in this project are 32
+        pixels high.
+    chain_length: int
+        Number of panels chained horizontally.  For ``width=128`` and
+        ``height=32`` this should be ``2``.
+    """
+
+    def __init__(self, width: int = 128, height: int = 32, chain_length: int = 2) -> None:
+        self.width = width
+        self.height = height
+        self.chain_length = chain_length
+
+        if RGBMatrix:
+            options = RGBMatrixOptions()
+            options.rows = height
+            options.cols = width // chain_length
+            options.chain_length = chain_length
+            options.parallel = 1
+            options.hardware_mapping = "adafruit-hat"
+            self.matrix = RGBMatrix(options=options)
+            LOGGER.debug("RGBMatrix initialized: %s", self.matrix)
+        else:  # pragma: no cover
+            self.matrix = None
+            LOGGER.warning("rgbmatrix library not available; falling back to console output")
+
+    # ------------------------------------------------------------------
+    def show_message(self, message: str) -> None:
+        """Display ``message`` on the matrix.
+
+        On actual hardware the message scrolls from right to left.  In test
+        environments the message is printed to STDOUT.
+        """
+
+        if self.matrix is None:  # pragma: no cover - console fallback
+            print(f"DISPLAY: {message}")
+            return
+
+        # Real hardware drawing: scroll the text across the display.
+        canvas = self.matrix.CreateFrameCanvas()
+        font = graphics.Font()
+        font.LoadFont("/usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.bdf")
+        text_color = graphics.Color(255, 255, 0)
+        pos = canvas.width
+        while pos + len(message) * 6 >= 0:
+            canvas.Clear()
+            graphics.DrawText(canvas, font, pos, 20, text_color, message)
+            pos -= 1
+            canvas = self.matrix.SwapOnVSync(canvas)
+        LOGGER.debug("Displayed message: %s", message)
+

--- a/news.py
+++ b/news.py
@@ -1,0 +1,40 @@
+"""Fetch headlines from an RSS feed for display on the matrix."""
+
+from __future__ import annotations
+
+import logging
+from typing import List
+
+import feedparser
+
+LOGGER = logging.getLogger(__name__)
+
+
+class NewsFetcher:
+    """Periodically fetch and cache headlines from an RSS feed."""
+
+    def __init__(self, feed_url: str = "https://news.google.com/rss") -> None:
+        self.feed_url = feed_url
+        self.headlines: List[str] = []
+
+    # ------------------------------------------------------------------
+    def set_feed(self, url: str) -> None:
+        self.feed_url = url
+        LOGGER.debug("News feed set to %s", url)
+
+    # ------------------------------------------------------------------
+    def fetch(self) -> None:
+        try:
+            feed = feedparser.parse(self.feed_url)
+            self.headlines = [entry.title for entry in feed.entries[:5]]
+            LOGGER.debug("Fetched %d headlines", len(self.headlines))
+        except Exception as exc:  # pragma: no cover
+            LOGGER.warning("Failed to fetch news: %s", exc)
+            self.headlines = []
+
+    # ------------------------------------------------------------------
+    def headline_string(self) -> str:
+        if not self.headlines:
+            self.fetch()
+        return " | ".join(self.headlines)
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+flask
+requests
+feedparser
+yfinance
+rgbmatrix

--- a/ticker_manager.py
+++ b/ticker_manager.py
@@ -1,0 +1,70 @@
+"""Manage stock and cryptocurrency tickers and retrieve prices."""
+
+from __future__ import annotations
+
+import logging
+from typing import Dict, Iterable, Set
+
+import requests
+import yfinance as yf
+
+LOGGER = logging.getLogger(__name__)
+
+
+class TickerManager:
+    """Store and update tickers for stocks and cryptocurrencies."""
+
+    def __init__(self) -> None:
+        self.stocks: Set[str] = set()
+        self.crypto: Set[str] = set()
+
+    # ------------------------------------------------------------------
+    def add_ticker(self, symbol: str, kind: str = "stock") -> None:
+        symbol = symbol.upper()
+        if kind == "crypto":
+            self.crypto.add(symbol)
+        else:
+            self.stocks.add(symbol)
+        LOGGER.debug("Added %s ticker: %s", kind, symbol)
+
+    # ------------------------------------------------------------------
+    def remove_ticker(self, symbol: str) -> None:
+        symbol = symbol.upper()
+        self.stocks.discard(symbol)
+        self.crypto.discard(symbol)
+        LOGGER.debug("Removed ticker: %s", symbol)
+
+    # ------------------------------------------------------------------
+    def _fetch_stock(self, symbol: str) -> str:
+        try:
+            ticker = yf.Ticker(symbol)
+            price = ticker.fast_info.get("last_price") or ticker.info.get("regularMarketPrice")
+            return f"{symbol}:{price:.2f}"
+        except Exception as exc:  # pragma: no cover - network failures
+            LOGGER.warning("Failed to fetch stock %s: %s", symbol, exc)
+            return f"{symbol}:N/A"
+
+    # ------------------------------------------------------------------
+    def _fetch_crypto(self, symbol: str) -> str:
+        try:
+            url = (
+                "https://api.coingecko.com/api/v3/simple/price?ids="
+                f"{symbol.lower()}&vs_currencies=usd"
+            )
+            resp = requests.get(url, timeout=10)
+            price = resp.json().get(symbol.lower(), {}).get("usd")
+            return f"{symbol}:{price:.2f}"
+        except Exception as exc:  # pragma: no cover
+            LOGGER.warning("Failed to fetch crypto %s: %s", symbol, exc)
+            return f"{symbol}:N/A"
+
+    # ------------------------------------------------------------------
+    def build_ticker_string(self) -> str:
+        parts = [self._fetch_stock(sym) for sym in sorted(self.stocks)]
+        parts.extend(self._fetch_crypto(sym) for sym in sorted(self.crypto))
+        return " | ".join(parts)
+
+    # ------------------------------------------------------------------
+    def as_dict(self) -> Dict[str, Iterable[str]]:
+        return {"stocks": sorted(self.stocks), "crypto": sorted(self.crypto)}
+


### PR DESCRIPTION
## Summary
- Implement MatrixDisplay abstraction for two 64x32 panels with console fallback
- Add Flask app to display clock, stock/crypto tickers and RSS headlines
- Provide web endpoints to manage ticker symbols and news feed
- Document setup and dependencies

## Testing
- `python -m py_compile app.py matrix_display.py ticker_manager.py news.py`


------
https://chatgpt.com/codex/tasks/task_e_68be93bf176883279a80450085589b52